### PR TITLE
首次加载时, 偶现无法加载子控制器的情况

### DIFF
--- a/QHPageViewController/QHPageViewController.m
+++ b/QHPageViewController/QHPageViewController.m
@@ -139,7 +139,7 @@ typedef NS_ENUM(NSUInteger, HTCMPageLifeStatus) {
         [self __removeAllControllers];
     }
     
-    if (self.targetWaitMoveToIndex!=nil) {
+    if (self.targetWaitMoveToIndex!=nil && self.numberOfViewControllers>0) {
         [self moveToControllerAtIndex:self.targetWaitMoveToIndex.integerValue animation:NO];
         self.targetWaitMoveToIndex = nil;
     }


### PR DESCRIPTION
首次加载 (self.numberOfViewControllers==0) 时, 调用了 reload, 而此函数中, 只判断了 self.targetWaitMoveToIndex!=nil, 导致self.targetWaitMoveToIndex = @(0) 的预设值意外被破坏了, 而后台数据返回后需要 reload 的时候, 无法调用 143 行的代码.